### PR TITLE
Fix Sunburst and Treemap charts when using plain dicts or series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
-0.1.0 (2019-12-02)
+0.1.2 (2019-12-??)
+==================
+
+Fixed
+-----
+- Sunburst and Treemap charts also work with dictionaries and pandas Series with a one-dimensional index (#4)
+
+
+0.1.1 (2019-12-02)
 ==================
 
 Added
 -----
-
 - `Sunburst`, `Treemap` and `Sankey` accept the same arguments as the corresponding Plotly object.
 - Nested arguments like `marker_colors` are also supported (this is Plotly's _magic underscore notation_).
 

--- a/easyplotly/internals.py
+++ b/easyplotly/internals.py
@@ -35,7 +35,7 @@ def sunburst_or_treemap(values, root_label=None, branchvalues='total', **kwargs)
 
     for item in org_tree:
         if isinstance(item, tuple):
-            value = values[item]
+            value = org_tree[item]
             if value < 0:
                 raise ValueError('Negative value {} for {}'.format(value, item))
 

--- a/tests/test_sunburst.py
+++ b/tests/test_sunburst.py
@@ -43,6 +43,18 @@ def test_sunburst_with_root(sunburst_with_root, sunburst_input):
     assert Sunburst(sunburst_input, root_label='') == sunburst_with_root
 
 
+def test_sunburst_simple_index():
+    sunburst_input = {'A': 2, 'B': 3}
+    sunburst_expected = go.Sunburst(
+        ids=['/A', '/B'],
+        labels=['A', 'B'],
+        parents=[None, None],
+        values=[2, 3],
+        branchvalues='total'
+    )
+    assert Sunburst(sunburst_input) == sunburst_expected
+
+
 def test_sunburst_remainder(sunburst_expected, sunburst_input):
     sunburst_expected.branchvalues = 'remainder'
     sunburst_expected.values = [1, 2, 1, 0, 0]


### PR DESCRIPTION
Sunburst and Treemap charts also work with dictionaries and pandas Series with a one-dimensional index (#4)